### PR TITLE
Tag quality of life improvements

### DIFF
--- a/src/electron/database/preparedStatements/collectionStatements.ts
+++ b/src/electron/database/preparedStatements/collectionStatements.ts
@@ -14,7 +14,9 @@ const prepared: () => PreparedStatementsFull = () => {
         "select c.collection_id, c.name " +
         "from images_collections i " +
         "left join collections c on i.collection_id = c.collection_id " +
-        "where i.image_id = ?"
+        "where i.image_id = ? " +
+        "order by " +
+        "name"
     )
 
     const createCollection = db.prepare("" +

--- a/src/electron/database/preparedStatements/tagStatements.ts
+++ b/src/electron/database/preparedStatements/tagStatements.ts
@@ -13,7 +13,9 @@ const prepared: () => PreparedStatementsFull = () => {
         "select t.tag_id, t.name " +
         "from images_tags i " +
         "left join tags t on i.tag_id = t.tag_id " +
-        "where i.image_id = ?"
+        "where i.image_id = ? " +
+        "order by " +
+        "name"
     )
 
     const createTag = db.prepare("" +

--- a/src/electron/database/preparedStatements/tagStatements.ts
+++ b/src/electron/database/preparedStatements/tagStatements.ts
@@ -28,6 +28,13 @@ const prepared: () => PreparedStatementsFull = () => {
         "select ?, ?"
     )
 
+    const addImageTagName = db.prepare("" +
+        "insert into images_tags " +
+        "select ?, tag_id " +
+        "from tags " +
+        "where name like ?"
+    )
+
     const removeImageTag = db.prepare("" +
         "delete from images_tags " +
         "where image_id = ? and tag_id = ?"
@@ -46,6 +53,7 @@ const prepared: () => PreparedStatementsFull = () => {
         runStatements: {
             createTag,
             addImageTag,
+            addImageTagName,
             removeImageTag,
             clearImageTag,
         }

--- a/src/react/image_viewer/components/AppViewer.tsx
+++ b/src/react/image_viewer/components/AppViewer.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react/index';
+import React, {useEffect, useRef} from 'react';
 import {channels} from "@utils/ipcCommands";
 import {SpeedDial, SpeedDialAction, SpeedDialIcon, styled} from "@mui/material";
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -25,8 +25,11 @@ function AppViewer(props: PropTypes) {
     const [imageFull, setImageFull] = useState(false)
     const [drawerTR, setDrawerTR] = useState(false)
 
+    const imageRef = useRef<HTMLDivElement>(null)
+
     useEffect(() => {
         updateImageData()
+        imageRef.current?.focus()
     }, [])
 
     useEffect(() => {
@@ -70,6 +73,7 @@ function AppViewer(props: PropTypes) {
         <View>
             <ImageContainer
                 tabIndex={1}
+                ref={imageRef}
                 onKeyDown={keyPressEvent}
                 open={editOpen}
                 landscape={(imageData)? (imageData.image_width > imageData.image_height): false}

--- a/src/react/image_viewer/components/AppViewer.tsx
+++ b/src/react/image_viewer/components/AppViewer.tsx
@@ -44,12 +44,12 @@ function AppViewer(props: PropTypes) {
     }
 
     const keyPressEvent = (e: KeyboardEvent) => {
-        e.preventDefault()
-
         if (e.key === "ArrowRight" && index+1 < imageList.length) {
+            e.preventDefault()
             onIndexChange(index+1)
         }
         if (e.key === "ArrowLeft" && index > 0) {
+            e.preventDefault()
             onIndexChange(index-1)
         }
     }
@@ -70,8 +70,8 @@ function AppViewer(props: PropTypes) {
         <View>
             <ImageContainer
                 tabIndex={1}
-                open={editOpen}
                 onKeyDown={keyPressEvent}
+                open={editOpen}
                 landscape={(imageData)? (imageData.image_width > imageData.image_height): false}
             >
                 {(image) && <ImageDisplay
@@ -82,10 +82,11 @@ function AppViewer(props: PropTypes) {
                     onClick={toggleImageFull}
                 />}
                 <Options
-                    ariaLabel=""
+                    ariaLabel="speed-dial"
                     sx={{ position: 'fixed', bottom: 16, right: 16 }}
-                    icon={<SpeedDialIcon icon={<MoreHorizIcon />} openIcon={<BookmarkBorderIcon />} />}
+                    icon={<SpeedDialIcon icon={<MoreHorizIcon />} openIcon={<BookmarkBorderIcon />}/>}
                     open={editOpen}
+                    FabProps={{tabIndex: -1}}
                 >
                     <SpeedDialAction
                         key={"editMetadata"}

--- a/src/react/image_viewer/components/MetadataEdit.tsx
+++ b/src/react/image_viewer/components/MetadataEdit.tsx
@@ -72,11 +72,18 @@ const MetadataEdit = (props: PropTypes) => {
             case "select":
                 if (tag?.value) {
                     window.api.db.getImages(sqlQueries.createTag, ({lastInsertRowid}: RunResult) => {
-                        window.api.db.getImages(
-                            sqlQueries.addImageTag, () => {
-                                updateImageTags()
-                            }, [imageData?.image_id, lastInsertRowid])
-                        updateTags()
+                        if (lastInsertRowid) {
+                            window.api.db.getImages(
+                                sqlQueries.addImageTag, () => {
+                                    updateImageTags()
+                                }, [imageData?.image_id, lastInsertRowid])
+                            updateTags()
+                        } else {
+                            window.api.db.getImages(
+                                sqlQueries.addImageTagName, () => {
+                                    updateImageTags()
+                                }, [imageData?.image_id, tag.value])
+                        }
                     }, tag?.value)
                 } else {
                     window.api.db.getImages(sqlQueries.addImageTag, () => {

--- a/src/react/image_viewer/components/TagSelector.tsx
+++ b/src/react/image_viewer/components/TagSelector.tsx
@@ -63,7 +63,9 @@ const TagSelector = <T extends ChipBase>(props: PropTypes<T>) => {
                 const { inputValue } = params;
 
                 if (freeSolo) {
-                    const isExisting = options.some((option) => inputValue === option.name);
+                    const isExisting = options.some((option) =>
+                        inputValue.toLowerCase() === option.name.toLowerCase()
+                    );
                     if (inputValue !== '' && !isExisting) {
                         return [...filtered, {
                             tag_id: 0,

--- a/src/react/image_viewer/components/TagSelector.tsx
+++ b/src/react/image_viewer/components/TagSelector.tsx
@@ -59,17 +59,17 @@ const TagSelector = <T extends ChipBase>(props: PropTypes<T>) => {
             isOptionEqualToValue={(option, value) => option.name === value.name}
             filterOptions={(options, params) => {
                 const without = props.excludeChips? _.without(options, ...props.excludeChips): options
-                const filtered = filter(without || options, params);
+                const filtered = filter(without, params);
                 const { inputValue } = params;
 
                 if (freeSolo) {
                     const isExisting = options.some((option) => inputValue === option.name);
                     if (inputValue !== '' && !isExisting) {
-                        return [{
+                        return [...filtered, {
                             tag_id: 0,
                             name: `Create "${inputValue}"`,
                             value: inputValue
-                        }, ...filtered]
+                        }]
                     }
                 }
 

--- a/src/react/image_viewer/components/TagSelector.tsx
+++ b/src/react/image_viewer/components/TagSelector.tsx
@@ -28,6 +28,7 @@ const TagSelector = <T extends ChipBase>(props: PropTypes<T>) => {
         reason: AutocompleteChangeReason,
         details: AutocompleteChangeDetails<T> | undefined
     ) => {
+        console.log()
         if (reason === "createOption" && onCreateTag)
             onCreateTag({name: "", value: details?.option as unknown as string})
         else if (reason === "selectOption" && onSelectTag)
@@ -55,6 +56,7 @@ const TagSelector = <T extends ChipBase>(props: PropTypes<T>) => {
             handleHomeEndKeys
             multiple
             selectOnFocus
+            autoHighlight
             getOptionLabel={option => option.name}
             isOptionEqualToValue={(option, value) => option.name === value.name}
             filterOptions={(options, params) => {

--- a/src/utils/sqlQueries.ts
+++ b/src/utils/sqlQueries.ts
@@ -14,6 +14,7 @@ const queries = {
     removeImageCollection: "removeImageCollection",
     clearImageCollection: "clearImageCollection",
     setImageTitle: "setImageTitle",
+    addImageTagName: "addImageTagName"
 }
 
 export default queries


### PR DESCRIPTION
# Change log

### Changed
- Selected tags and collections are now sorted
- Hitting enter will now add the tag or collection to the image even if it already exists
- Moved the "create new" chip to the bottom of the list
- Tab will now skip the speed dial
- Tags and collections are now case insensitive unique
- Arrow keys will now work immediately when viewing an image
- The first chip in the tag or collection selector will be highlighted